### PR TITLE
Debug: IncludeUntracked missing files in new untracked directories 

### DIFF
--- a/changelist_init/__init__.py
+++ b/changelist_init/__init__.py
@@ -18,9 +18,9 @@ def initialize_file_changes(
     """ Get up-to-date File Change information in a list.
     """
     if input_data.include_untracked:
-        file_status_generator = get_status_lists().merge_all()
+        file_status_generator = get_status_lists(True).merge_all()
     else:
-        file_status_generator = get_status_lists().merge_tracked()
+        file_status_generator = get_status_lists(False).merge_tracked()
     return list(
         _map_file_status_to_changes(file_status_generator)
     )

--- a/changelist_init/git/__init__.py
+++ b/changelist_init/git/__init__.py
@@ -4,12 +4,14 @@ from changelist_init.git.git_status_lists import GitStatusLists
 from changelist_init.git import status_runner, status_reader
 
 
-def get_status_lists() -> GitStatusLists:
+def get_status_lists(
+    include_untracked: bool = False,
+) -> GitStatusLists:
     """ Executes the Complete Git Status into File Change Operation.
 
     Returns:
     list[FileChange] - The List of FileChange information from Git Status.
     """
     return status_reader.read_git_status_output(
-        status_runner.run_git_status()
+        status_runner.run_git_status() if not include_untracked else status_runner.run_untracked_status()
     )

--- a/changelist_init/git/status_reader.py
+++ b/changelist_init/git/status_reader.py
@@ -22,7 +22,7 @@ def read_git_status_output(
         if (file_status := read_git_status_line(f)) is not None:
             status_lists.add_file_status(file_status)
         else:
-            print(f"Failed To Process File Line: ${f}")
+            print(f"Skipped: ${f}")
     return status_lists
 
 
@@ -35,7 +35,9 @@ def read_git_status_line(
         return None
     if len(file_status_line.strip()) < 3:
         return None
+    if file_status_line.endswith('/'):
+        return None
     return GitFileStatus(
-        file_status_line[:2],
-        file_status_line[3:],
+        code=file_status_line[:2],
+        file_path=file_status_line[3:],
     )

--- a/changelist_init/git/status_runner.py
+++ b/changelist_init/git/status_runner.py
@@ -28,7 +28,7 @@ def run_untracked_status() -> str:
     """
     # Add All Untracked Paths without staging
     git_add_output = subprocess.run(
-        args='git add -N .',
+        args=['git', 'add', '-N', '.'],
         capture_output=True,
         text=True,
         universal_newlines=True,

--- a/changelist_init/git/status_runner.py
+++ b/changelist_init/git/status_runner.py
@@ -10,7 +10,7 @@ def run_git_status() -> str:
     str - The output of the Git Status Operation.
     """
     result = subprocess.run(
-        args=['git', '--no-optional-locks', 'status', '--porcelain'],
+        args=['git', '--no-optional-locks', 'status', '--porcelain', '--no-renames'],
         capture_output=True,
         text=True,
         universal_newlines=True,
@@ -20,3 +20,34 @@ def run_git_status() -> str:
     if (error := result.stderr) is not None and not len(error) < 1:
         exit(f"Git Status Runner Error: {error}")
     return result.stdout
+
+
+def run_untracked_status() -> str:
+    """ Configure git for obtaining untracked files, then reset.
+        Uses multiple git commands to achieve the desired result.
+    """
+    # Add All Untracked Paths without staging
+    git_add_output = subprocess.run(
+        args='git add -N .',
+        capture_output=True,
+        text=True,
+        universal_newlines=True,
+        shell=False,
+        timeout=3,
+    )
+    if (error := git_add_output.stderr) is not None and not len(error) < 1:
+        exit(f"Git Add Error: {error}")
+    #
+    result = run_git_status()
+    # Reset git to remove Untracked paths
+    git_reset_output = subprocess.run(
+        args=['git', 'reset'],
+        capture_output=True,
+        text=True,
+        universal_newlines=True,
+        shell=False,
+        timeout=3,
+    )
+    if (error := git_add_output.stderr) is not None and not len(error) < 1:
+        exit(f"Git Reset Error: {error}")
+    return result

--- a/test/changelist_init/git/test_status_runner.py
+++ b/test/changelist_init/git/test_status_runner.py
@@ -6,7 +6,7 @@ import tempfile
 from pathlib import Path
 import pytest
 
-from changelist_init.git.status_runner import run_git_status
+from changelist_init.git.status_runner import run_git_status, run_untracked_status
 from test.changelist_init.git import provider
 
 
@@ -107,7 +107,7 @@ def single_unstaged_delete_repo():
     # Commit
     subprocess.run(['git', 'add', 'setup.py'])
     subprocess.run(['git', 'commit', '-m', '"Init!"'], capture_output=True)
-    # Modify
+    # Delete
     setup_file.unlink()
     # Ready For Test Case
     yield tdir
@@ -137,6 +137,33 @@ def single_staged_delete_repo():
     setup_file.unlink()
     # Stage
     subprocess.run(['git', 'add', 'setup.py'])
+    # Ready For Test Case
+    yield tdir
+    # After
+    os.chdir(initial_cwd)
+    tdir.cleanup()
+
+
+@pytest.fixture
+def single_unstaged_plus_multi_files_in_new_dir_repo():
+    tdir = tempfile.TemporaryDirectory()
+    initial_cwd = os.getcwd()
+    os.chdir(tdir.name)
+    subprocess.run(['git', 'init'], capture_output=True,)
+    # Setup Files
+    setup_file = Path(tdir.name + "/setup.py")
+    setup_file.touch()
+    setup_file.write_text("Hellow")
+    # Create new Dir
+    new_dir = (setup_file.parent / "test")
+    new_dir.mkdir()
+    # Create Files
+    new_init_file = new_dir / "__init__.py"
+    new_init_file.touch()
+    new_init_file.write_text('"""  """')
+    new_src_file = new_dir / "source_file.py"
+    new_src_file.touch()
+    new_src_file.write_text("src")
     # Ready For Test Case
     yield tdir
     # After
@@ -174,7 +201,7 @@ def test_run_git_status_single_staged_create_returns_staged_create(single_staged
     assert result == provider.single_staged_modify() + "\n"
 
 
-def test_run_git_status_single_unstaged_delete_returns_staged_create(single_unstaged_delete_repo):
+def test_run_git_status_single_unstaged_delete_returns_unstaged_delete(single_unstaged_delete_repo):
     result = run_git_status()
     assert result == provider.single_unstaged_delete() + "\n"
 
@@ -182,3 +209,52 @@ def test_run_git_status_single_unstaged_delete_returns_staged_create(single_unst
 def test_run_git_status_single_staged_delete_returns_staged_create(single_staged_delete_repo):
     result = run_git_status()
     assert result == provider.single_staged_delete() + "\n"
+
+
+def test_run_git_status_multi_files_in_new_dir_returns_untracked_single_and_new_dir(
+        single_unstaged_plus_multi_files_in_new_dir_repo):
+    result = run_git_status()
+    assert result == f"""{provider.single_untracked()}
+?? test/
+"""
+
+
+def test_run_untracked_status_empty_git_repo(temp_cwd):
+    subprocess.run(['git', 'init'], capture_output=True)
+    result = run_untracked_status()
+    assert len(result) == 0
+
+
+def test_run_untracked_status_single_untracked_returns_unstaged_create(single_untracked_repo):
+    result = run_untracked_status()
+    assert result == provider.single_unstaged_create() + "\n"
+
+
+def test_run_untracked_status_single_unstaged_modify_returns_unstaged_modify(single_unstaged_modify_repo):
+    result = run_untracked_status()
+    assert result == provider.single_unstaged_modify() + "\n"
+
+
+def test_run_untracked_status_single_staged_modify_returns_staged_modify(single_staged_modify_repo):
+    result = run_untracked_status()
+    assert result == provider.single_staged_modify() + "\n"
+
+
+def test_run_untracked_status_single_unstaged_delete_returns_staged_delete(single_unstaged_delete_repo):
+    # The Git Add operation seems to stage deleted files
+    result = run_untracked_status()
+    assert result == provider.single_staged_delete() + "\n"
+
+
+def test_run_untracked_status_single_staged_delete_returns_staged_delete(single_staged_delete_repo):
+    result = run_untracked_status()
+    assert result == provider.single_staged_delete() + "\n"
+
+
+def test_run_untracked_status_multi_files_in_new_dir_returns_staged_create(
+        single_unstaged_plus_multi_files_in_new_dir_repo):
+    result = run_untracked_status()
+    assert result == f"""{provider.single_unstaged_create()}
+ A test/__init__.py
+ A test/source_file.py
+"""

--- a/test/changelist_init/test_init.py
+++ b/test/changelist_init/test_init.py
@@ -129,7 +129,8 @@ def test_initialize_file_changes_all_changes_given_multi_init_this_returns_file_
     with pytest.MonkeyPatch.context() as c:
         c.setattr(subprocess, 'run', lambda **kwargs: wrap_stdout(provider.multi_init_this()))
         result = initialize_file_changes(input_all)
-    assert len(result) == 35
+    # Includes untracked files, but ignores Directories
+    assert len(result) == 33
 
 
 def test_merge_file_changes_empty_lists_returns_true():


### PR DESCRIPTION
# Debug
The **IncludeUntracked** option is a valuable feature for new file discovery.

Using it, one would expect every new non-ignored file to be added to the changelists data. The alternative if not using this option, is to independently run `git add` on new untracked files.

When using this option, it is important to have a complete `.gitignore` file that excludes everything you do not want in your changelists.

## Problem
`git status` only shows the first directory in the path of new "untracked" files.

## Resolution
The solution used here is to run a `git add` operation with the `-N` option before running `git status`. This includes the "untracked" file paths without staging them, so they appear as an Add file with the A status code. These "untracked" files are removed from the index afterwards using `git reset`, but they will be included in the changelists data file.